### PR TITLE
Fixed incorrect binary field check; fixes issues with nested Codable

### DIFF
--- a/Sources/MariaDB/MySQLStmt.swift
+++ b/Sources/MariaDB/MySQLStmt.swift
@@ -99,7 +99,7 @@ public final class MySQLStmt {
 			 MYSQL_TYPE_MEDIUM_BLOB,
 			 MYSQL_TYPE_LONG_BLOB,
 			 MYSQL_TYPE_BLOB:
-			if (field.pointee.flags & UInt32(BINARY_FLAG)) != 0 {
+			if field.pointee.charsetnr == 63 /* binary */ {
 				return .bytes
 			}
 			fallthrough
@@ -581,7 +581,7 @@ public final class MySQLStmt {
 				 MYSQL_TYPE_MEDIUM_BLOB,
 				 MYSQL_TYPE_LONG_BLOB,
 				 MYSQL_TYPE_BLOB:
-				if ( (field.pointee.flags & UInt32(BINARY_FLAG)) != 0) {
+				if field.pointee.charsetnr == 63 /* binary */ {
 					return .bytes(type)
 				}
 				fallthrough

--- a/Tests/MariaDBTests/MariaDBTests.swift
+++ b/Tests/MariaDBTests/MariaDBTests.swift
@@ -1435,7 +1435,6 @@ class MariaDBTests: XCTestCase {
 	}
 	
 	func testCodableProperty() {
-		/*
 		do {
 			struct Sub: Codable {
 				let id: Int
@@ -1456,7 +1455,6 @@ class MariaDBTests: XCTestCase {
 		} catch {
 			XCTFail("\(error)")
 		}
-		*/
 	}
 	
 	func testBadDecoding() {


### PR DESCRIPTION
Please see PerfectlySoft/Perfect-MySQL#50 for details.

Notably this broke nested Codable support. In fact this is exactly what is tested in `testCodableProperty` but the test was commented out.

This pull request fixes the bug behind that test breaking and restores the test.